### PR TITLE
Multiple cache misses on concurrent requests

### DIFF
--- a/src/Web.Application/Program.cs
+++ b/src/Web.Application/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddMudServices();
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddLogging();
+builder.Services.AddLazyCache();
 
 builder.Host.UseSerilog((context, configuration) =>
     configuration.ReadFrom.Configuration(context.Configuration)

--- a/src/Web.Application/Web.Application.csproj
+++ b/src/Web.Application/Web.Application.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Blazor-ApexCharts" Version="2.1.0" />
+      <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
       <PackageReference Include="MudBlazor" Version="6.11.1" />
       <PackageReference Include="protobuf-net" Version="3.2.30" />
       <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />


### PR DESCRIPTION
### Issue
Native `IMemory` cache will invoke the cache factory multiple times if several requests arrive at the same time.  

This PR adds the LazyCache package that already has built-in behaviors for concurrent scenarios, preventing redundant cache misses.

Closes #21 