### PR TITLE
Enable optimized Wolverine code generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,7 @@
 .vs
 .vscode
 **/steamAvatars
-**/Web.UI/Internal
+**/Internal/Generated
 **/bin
 **/obj
 **/.toolstarget

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,8 @@
 .idea
 .vs
 .vscode
+**/steamAvatars
+**/Web.UI/Internal
 **/bin
 **/obj
 **/.toolstarget

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ mono_crash.*
 appsettings.Development.json
 steamAvatars/
 
+# Wolverine code generation
+**/Web.UI/Internal/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ appsettings.Development.json
 steamAvatars/
 
 # Wolverine code generation
-**/Web.UI/Internal/
+**/Internal/Generated/
 
 # Build results
 [Dd]ebug/

--- a/dockerfile
+++ b/dockerfile
@@ -6,6 +6,9 @@ ARG RELEASE_VERSION
 WORKDIR /app
 COPY . .
 RUN dotnet restore BifrostHub.sln --no-cache
+WORKDIR /app/src/Web.UI
+RUN dotnet run --launch-profile CI -- codegen write && dotnet run --launch-profile CI -- codegen test
+WORKDIR /app
 RUN dotnet build --no-restore --configuration Release BifrostHub.sln -p:Version=$RELEASE_VERSION
 
 WORKDIR /app/src/Web.UI

--- a/src/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace BifrostHub.Infrastructure.Extensions;
+
+using Hangfire;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+public static class ApplicationBuilderExtensions
+{
+    public static IApplicationBuilder UseConfigurableHangfireDashboard(this IApplicationBuilder builder)
+    {
+        var environment = builder.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
+        return environment.IsContinuousIntegration() ? builder : builder.UseHangfireDashboard();
+    }
+}

--- a/src/Infrastructure/Extensions/HostEnvironmentExtensions.cs
+++ b/src/Infrastructure/Extensions/HostEnvironmentExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace BifrostHub.Infrastructure.Extensions;
+
+using Microsoft.Extensions.Hosting;
+
+public static class HostEnvironmentExtensions
+{
+    private const string ContinuousIntegration = "CI";
+
+    public static bool IsContinuousIntegration(this IHostEnvironment hostEnvironment) =>
+        hostEnvironment.IsEnvironment(ContinuousIntegration);
+}

--- a/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -122,7 +122,7 @@ public static class ServiceCollectionExtensions
                         BackupStrategy = new CollectionMongoBackupStrategy()
                     },
                     Prefix = "hangfire",
-                    CheckConnection = true
+                    CheckConnection = false
                 };
                 
                 configuration

--- a/src/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Infrastructure/Extensions/WebApplicationBuilderExtensions.cs
@@ -7,7 +7,7 @@ using Wolverine;
 
 public static class WebApplicationBuilderExtensions
 {
-    public static ConfigureHostBuilder AddInfraDependencies(this ConfigureHostBuilder builder)
+    public static ConfigureHostBuilder AddInfraDependencies(this ConfigureHostBuilder builder, Type applicationAssemblyType)
     {
         builder
             .UseSerilog((context, configuration) =>
@@ -15,6 +15,12 @@ public static class WebApplicationBuilderExtensions
                 .Enrich.WithProperty("Version", context.Configuration["APP_VERSION"]))
             .UseWolverine(options =>
             {
+                options.ApplicationAssembly = applicationAssemblyType.Assembly;
+                
+                // Uses TypeLoadMode.Auto on Development environment
+                // Uses TypeLoadMode.Static on every other environment
+                options.OptimizeArtifactWorkflow();
+                
                 options.Discovery.IncludeAssembly(typeof(IOdinEyeApiClient).Assembly);
                 options.Durability.Mode = DurabilityMode.MediatorOnly;
             });

--- a/src/Web.UI/Program.cs
+++ b/src/Web.UI/Program.cs
@@ -1,6 +1,5 @@
 using BifrostHub.Application.Extensions;
 using BifrostHub.Infrastructure.Extensions;
-using Hangfire;
 using MudBlazor.Services;
 using Oakton;
 
@@ -30,7 +29,7 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.UseStaticFiles();
-app.UseHangfireDashboard();
+app.UseConfigurableHangfireDashboard();
 
 app.UseRouting();
 

--- a/src/Web.UI/Program.cs
+++ b/src/Web.UI/Program.cs
@@ -2,6 +2,7 @@ using BifrostHub.Application.Extensions;
 using BifrostHub.Infrastructure.Extensions;
 using Hangfire;
 using MudBlazor.Services;
+using Oakton;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,7 @@ builder.Services
     .AddRazorPages();
 builder.Services.AddServerSideBlazor();
 
-builder.Host.AddInfraDependencies();
+builder.Host.AddInfraDependencies(typeof(Program));
 builder.Services
     .AddInfraDependencies()
     .AddApplicationDependencies();
@@ -36,4 +37,5 @@ app.UseRouting();
 app.MapBlazorHub();
 app.MapFallbackToPage("/_Host");
 
-app.Run();
+// Required to parse Wolverine code generation commands
+return await app.RunOaktonCommands(args);

--- a/src/Web.UI/Properties/launchSettings.json
+++ b/src/Web.UI/Properties/launchSettings.json
@@ -18,6 +18,16 @@
         "APP_VERSION": "0.0.0-local"
       }
     },
+    "CI": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7199;http://localhost:5134",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "CI",
+        "APP_VERSION": "0.0.0-local"
+      }
+    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,


### PR DESCRIPTION
Detailed changes:

- Enabled optimized worflow for handler code generation
  - When environment is **development**:
    - Hybrid approach that first tries to locate the types from the application assembly, but falls back to generating the code and dynamic type. Also writes the generated source code file to disk
  - On every other environment:
    -  Never generate types at runtime, but instead try to locate the generated types from the main application assembly
- Added a new dockerfile command for code generation
- Added a new `CI` launch profile that sets the environment as `CI`. This profile is used by the code generation step
- Configured app dependencies, such as Hangfire, to disable usage if environment is `CI`
  - This is required as the codegen step will run the app and it will fail if the app attempts a database connection 